### PR TITLE
fix: imports order in .brs files stopped working

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,24 +105,92 @@ A rule to use with [Kopytko Packager](https://github.com/getndazn/kopytko-packag
 and [Kopytko Unit Testing Framework](https://github.com/getndazn/kopytko-unit-testing-framework) 's mocking mechanism.
 
 Enforces a proper alphabetical and path-specific order of `@import` and `@mock` annotations:
-- `@mock` annotations have to be after all `@import` annotations
-- alphabetical order of paths
-- nested paths have to be declared after their root path
+1. imports or mocks from external packages have to be before local ones
+2. `@mock` annotations have to be after all `@import` annotations
+3. alphabetical order of external packages names
+4. alphabetical order of paths
+5. nested paths have to be declared after their root path
 
-Examples of **incorrect** code for this rule:
+#### External packages before local
+
+Example of **incorrect** code:
 ```brightscript
-' @mock /components/mocked-function.brs
-' @import /components/nested/cool-function.brs
-' @import /components/nested/another-function.brs
 ' @import /components/main-function.brs
+' @import /components/nested/another-function.brs
+' @import /components/nested/cool-function.brs
+' @import /components/nested/some-function.brs from package-name
+' @mock /components/mocked-function.brs
+' @mock /components/some-mocked-function.brs from package-name
 ```
 
-Examples of **correct** code for this rule:
+Example of **correct** code:
+```brightscript
+' @import /components/nested/some-function.brs from package-name
+' @mock /components/some-mocked-function.brs from package-name
+' @import /components/main-function.brs
+' @import /components/nested/another-function.brs
+' @import /components/nested/cool-function.brs
+' @mock /components/mocked-function.brs
+```
+
+#### Imports before mocks
+
+Example of **incorrect** code:
+```brightscript
+' @mock /components/mocked-function.brs
+' @import /components/main-function.brs
+' @import /components/nested/another-function.brs
+' @import /components/nested/cool-function.brs
+```
+
+Example of **correct** code:
 ```brightscript
 ' @import /components/main-function.brs
 ' @import /components/nested/another-function.brs
 ' @import /components/nested/cool-function.brs
 ' @mock /components/mocked-function.brs
+```
+
+#### Alphabetical order of external packages names
+
+Example of **incorrect** code:
+```brightscript
+' @import /components/a-function.brs from package-name
+' @import /components/some-function.brs from another-package-name
+' @mock /components/another-mocked-function.brs from package-name
+' @mock /components/some-mocked-function.brs from another-package-name
+' @import /components/main-function.brs
+' @mock /components/mocked-function.brs
+```
+
+Example of **correct** code:
+```brightscript
+' @import /components/some-function.brs from another-package-name
+' @import /components/a-function.brs from package-name
+' @mock /components/some-mocked-function.brs from another-package-name
+' @mock /components/another-mocked-function.brs from package-name
+' @import /components/main-function.brs
+' @mock /components/mocked-function.brs
+```
+
+#### Alphabetical order of paths
+
+Example of **incorrect** code:
+```brightscript
+' @import /components/nested/another-function.brs
+' @import /components/main-function.brs
+' @import /components/nested/cool-function.brs
+' @mock /components/some-mocked-function.brs
+' @mock /components/mocked-function.brs
+```
+
+Example of **correct** code:
+```brightscript
+' @import /components/main-function.brs
+' @import /components/nested/another-function.brs
+' @import /components/nested/cool-function.brs
+' @mock /components/mocked-function.brs
+' @mock /components/some-mocked-function.brs
 ```
 
 


### PR DESCRIPTION
BREAKING CHANGE: Changed order of imports

## What did you implement:

Closes [#7](https://github.com/getndazn/kopytko-eslint-plugin/issues/7)

Fixes dependency order checks after adding the possibility to use external packages in the kopytko-packager.

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Checked locally.

## Todos:

- [x] Write documentation (if required)
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** YES
